### PR TITLE
Fix windows related issue to use full path to start script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,4 @@ COPY ./backend/api /backend/api
 
 COPY --from=build /frontend/dist/ /frontend
 
-ENTRYPOINT ./start.sh
+ENTRYPOINT /backend/start.sh


### PR DESCRIPTION
## Description
Use full path to start.sh which fixes issue on windows machines (does not affect linux).